### PR TITLE
Github Actionsでnormを実行できるように

### DIFF
--- a/.github/workflows/norminette.yml
+++ b/.github/workflows/norminette.yml
@@ -26,4 +26,6 @@ jobs:
         run: |
           [ $(norminette | grep -vE 'OK|Error!' \
           | grep -v "Missing or invalid 42 header" \
+          | grep -v "Function has more than 25 lines" \
+          | grep -v "Too many functions in file" \
           | wc -l) -eq 0 ]


### PR DESCRIPTION
## 概要
Github Actionsでnormをチェックするようにしました。
以下の3つエラーを無視するようにしました。必要に応じて調整しようと思います。
- 42headerがないとき
- 関数が25行を超えるとき
- 1ファイルに6つ以上関数があるとき