### PR TITLE
プロンプトからの入力を受け取るようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+minishell
 .DS_Store
 **/build/*
 !.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ XSYSCALL_SRCS = $(addprefix srcs/xsyscall/, \
 		)
 SRCS = main.c $(XSYSCALL_SRCS) 
 OBJS = $(SRCS:%.c=%.o)
-LIBS = -lft -Llibft
+LIBS = -lft -Llibft -lreadline
 INCS = -Ilibft/includes -Iincludes
 
 $(NAME): $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ XSYSCALL_SRCS = $(addprefix srcs/xsyscall/, \
 		)
 SRCS = main.c $(XSYSCALL_SRCS) 
 OBJS = $(SRCS:%.c=%.o)
-LIBS = -lft -Llibft -lreadline
-INCS = -Ilibft/includes -Iincludes
+LIBS = -lft -Llibft -lreadline -L$(shell brew --prefix readline)/lib
+INCS = -Ilibft/includes -Iincludes -I$(shell brew --prefix readline)/include
 
 $(NAME): $(OBJS)
 	make -C libft

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # minishell
+
+readlineを使用するのでhomebrewで取得する。
+```bash
+brew readline
+```

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,0 +1,1 @@
+minishellはEOFで終了する。

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,1 +1,4 @@
 minishellはEOFで終了する。
+
+SIGQUIT(Ctrl-\)は無視する。
+SIGINT(Ctrl-C)は新しいプロンプトを表示する。

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -16,6 +16,7 @@
 # include "lexer.h"
 # include "executer.h"
 # include <readline/readline.h>
+# include <readline/history.h>
 # include <signal.h>
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -16,5 +16,6 @@
 # include "lexer.h"
 # include "executer.h"
 # include <readline/readline.h>
+# include <signal.h>
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -1,7 +1,20 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   minishell.h                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ahayashi <ahayashi@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/02/16 16:42:14 by ahayashi          #+#    #+#             */
+/*   Updated: 2022/02/16 16:42:14 by ahayashi         ###   ########.jp       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
 # include "lexer.h"
 # include "executer.h"
+# include <readline/readline.h>
 
 #endif

--- a/main.c
+++ b/main.c
@@ -11,7 +11,6 @@
 /* ************************************************************************** */
 
 #include "minishell.h"
-#include <readline/readline.h>
 
 int	main(int argc, char **argv, char **env)
 {
@@ -20,15 +19,18 @@ int	main(int argc, char **argv, char **env)
 	(void)argv;
 	(void)env;
 
-    while (1)
-    {
-        line = readline("> ");
-        if (line == NULL || ft_strlen(line) == 0)
-        {
-            free(line);
-			break;
-        }
-        printf("line is '%s'\n", line);
-        free(line);
-    }
+	while (1)
+	{
+		line = readline("> ");
+		if (line == NULL)
+			break ;
+		if (*line == '\0')
+		{
+			free(line);
+			continue ;
+		}
+		printf("line is '%s'\n", line);
+		add_history(line);
+		free(line);
+	}
 }

--- a/main.c
+++ b/main.c
@@ -19,6 +19,8 @@ int	main(int argc, char **argv, char **env)
 	(void)argc;
 	(void)argv;
 	(void)env;
+
+	signal(SIGQUIT, SIG_IGN);
 	while (1)
 	{
 		line = readline("> ");

--- a/main.c
+++ b/main.c
@@ -1,9 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   main.c                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ahayashi <ahayashi@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/02/16 16:09:06 by ahayashi          #+#    #+#             */
+/*   Updated: 2022/02/16 16:09:06 by ahayashi         ###   ########.jp       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "minishell.h"
+#include <readline/readline.h>
 
 int	main(int argc, char **argv, char **env)
 {
+	char *line = NULL;
 	(void)argc;
 	(void)argv;
 	(void)env;
-	printf("HELLO WORLD\n");
+
+    while (1)
+    {
+        line = readline("> ");
+        if (line == NULL || ft_strlen(line) == 0)
+        {
+            free(line);
+			break;
+        }
+        printf("line is '%s'\n", line);
+        free(line);
+    }
 }

--- a/main.c
+++ b/main.c
@@ -12,6 +12,11 @@
 
 #include "minishell.h"
 
+void	set_signal(void)
+{
+	signal(SIGQUIT, SIG_IGN);
+}
+
 int	main(int argc, char **argv, char **env)
 {
 	char	*line;

--- a/main.c
+++ b/main.c
@@ -12,9 +12,26 @@
 
 #include "minishell.h"
 
+/*
+ * ^Cは表示されてしまう
+ */
+void	sigint_handler(int signal)
+{
+	(void)signal;
+	printf("\n");
+	rl_replace_line("", 0);
+	rl_on_new_line();
+	rl_redisplay();
+	rl_replace_line("", 0);
+}
+
+/*
+ * SIGQUITは特に何もしなくても無視されていそう　
+ */
 void	set_signal(void)
 {
 	signal(SIGQUIT, SIG_IGN);
+	signal(SIGINT, sigint_handler);
 }
 
 int	main(int argc, char **argv, char **env)
@@ -24,8 +41,7 @@ int	main(int argc, char **argv, char **env)
 	(void)argc;
 	(void)argv;
 	(void)env;
-
-	signal(SIGQUIT, SIG_IGN);
+	set_signal();
 	while (1)
 	{
 		line = readline("> ");

--- a/main.c
+++ b/main.c
@@ -14,11 +14,11 @@
 
 int	main(int argc, char **argv, char **env)
 {
-	char *line = NULL;
+	char	*line;
+
 	(void)argc;
 	(void)argv;
 	(void)env;
-
 	while (1)
 	{
 		line = readline("> ");

--- a/tests/google_tests/CMakeLists.txt
+++ b/tests/google_tests/CMakeLists.txt
@@ -10,6 +10,8 @@ file(GLOB XSYSCALL "../../srcs/xsyscall/*.c")
 
 include_directories("../../libft/includes")
 include_directories("../../includes")
+# brewでインストールしたreadlineのincludeファイル
+include_directories("/usr/local/opt/readline/include")
 
 add_library(minishell
   STATIC


### PR DESCRIPTION
## 概要
シグナルなどを考慮したプロンプトからの入力の受付処理を実装しました。

- EOF(Ctrl-D): シェルを終了するように
- SIGQUIT(Ctrl-\): シグナルを無視するように
- SIGINT(Ctrl-C): 新しいプロンプトを表示するように

SIGQUITについては、ignoreしなくてもデフォルトで無視されていそう。
子プロセスで実行したコマンドについて挙動が違うかも？


### 参考
- [Readline Library]
- [Basic Usage]：基本的なreadlineの挙動
- [Interactive Shell]

[Readline Library]: https://tiswww.case.edu/php/chet/readline/readline.html
[Basic Usage]: https://tiswww.case.edu/php/chet/readline/readline.html#SEC24
[Interactive Shell]: https://www.gnu.org/software/bash/manual/bash.html#Interactive-Shells