### PR TITLE
コンパイルできなくなっていたので修正

### DIFF
--- a/includes/builtin.h
+++ b/includes/builtin.h
@@ -24,6 +24,7 @@ int	cd(int argc, char **argv);
 int	echo(int argc, char **argv);
 int	env(int argc, char **argv);
 int	builtin_exit(int argc, char **argv);
+int	builtin_export(int argc, char **argv);
 int	pwd(int argc, char **argv);
 int	unset(int argc, char **argv);
 


### PR DESCRIPTION
## 概要
#73 の修正でconflict解消時にヘッダーのexportの定義が消えていた。