### PR TITLE
諸々対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,7 @@ RUN (cd /usr/src/googletest && cmake . && cmake --build . --target install)
 
 RUN pip install norminette==3.3.2
 
+# MacとLinuxでgrepのいる場所が違っているために統合テストが失敗してしまう
+RUN cp /bin/grep /usr/bin/grep
+
 CMD /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ re: fclean all
 .PHONY: all fclean clean re
 
 .PHONY: test
-test: ultest itest
+test: utest itest
 
 .PHONY: ltest
 ltest: ultest iltest

--- a/srcs/lexer/lexer.c
+++ b/srcs/lexer/lexer.c
@@ -121,7 +121,7 @@ t_token	*lexer(char *str)
 		else
 			str += lexer_not_neutral(mgr, str);
 	}
-	if (mgr->is_misuse_builtin)
+	if (mgr->is_misuse_builtin || mgr->state != NEUTRAL)
 	{
 		g_last_exit_status = STATUS_MISUSE_BUILTIN;
 		puterr("minishell", "syntax error");

--- a/srcs/lexer/lexer.c
+++ b/srcs/lexer/lexer.c
@@ -112,7 +112,7 @@ t_token	*lexer(char *str)
 	mgr->word_index = 0;
 	while (*str != '\0')
 	{
-		while (*str == ' ' && mgr->state == NEUTRAL)
+		while ((*str == ' ' || *str == '\t') && mgr->state == NEUTRAL)
 			str++;
 		if (*str == '\0')
 			break ;

--- a/srcs/lexer/lexer_utils.c
+++ b/srcs/lexer/lexer_utils.c
@@ -14,7 +14,7 @@
 
 bool	is_special_char(char c)
 {
-	return (c == ' ' || c == '\0' || c == '|'
+	return (c == ' ' || c == '\t' || c == '\0' || c == '|'
 		|| c == '>' || c == '<' );
 }
 

--- a/tests/google_tests/lexer.cpp
+++ b/tests/google_tests/lexer.cpp
@@ -388,3 +388,33 @@ TEST_F(LexerTest, not_close_cbracket)
 
 	lexer_test(input, token_len, expected_token, expected_word);
 }
+
+TEST_F(LexerTest, not_close_sq_edge_case)
+{
+	char *input = "echo '";
+	int token_len = -1;
+	int *expected_token = NULL;
+	char **expected_word = NULL;
+
+	lexer_test(input, token_len, expected_token, expected_word);
+}
+
+TEST_F(LexerTest, not_close_dq_edge_case)
+{
+	char *input = "echo \"";
+	int token_len = -1;
+	int *expected_token = NULL;
+	char **expected_word = NULL;
+
+	lexer_test(input, token_len, expected_token, expected_word);
+}
+
+TEST_F(LexerTest, not_close_bq_edge_case)
+{
+	char *input = "echo `";
+	int token_len = -1;
+	int *expected_token = NULL;
+	char **expected_word = NULL;
+
+	lexer_test(input, token_len, expected_token, expected_word);
+}

--- a/tests/google_tests/lexer.cpp
+++ b/tests/google_tests/lexer.cpp
@@ -418,3 +418,13 @@ TEST_F(LexerTest, not_close_bq_edge_case)
 
 	lexer_test(input, token_len, expected_token, expected_word);
 }
+
+TEST_F(LexerTest, tab_is_files_separator)
+{
+	char *input = "ls\t-la";
+	int token_len = 3;
+	int expected_token[] = {T_WORD, T_WORD, NULL};
+	char *expected_word[] = {"ls", "-la", NULL};
+
+	lexer_test(input, token_len, expected_token, expected_word);
+}

--- a/tests/google_tests/main.cpp
+++ b/tests/google_tests/main.cpp
@@ -1,5 +1,9 @@
 #include <gtest/gtest.h>
 
+extern "C" {
+int	g_last_exit_status;
+}
+
 int main(int argc, char **argv)
 {
 	testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## 概要
以下を対応しました。
- GoogleTestsがコンパイルできなくなっていたのを修正
- 閉じられていないクオート文字が最後にある場合にシンタックスエラーにするように
- スペースに加えてタブも区切り文字として扱うように